### PR TITLE
Feat/loan model and screen

### DIFF
--- a/lib/data/model/loan.dart
+++ b/lib/data/model/loan.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:rocket_pocket/data/local/database.dart' as db;
 import 'package:rocket_pocket/data/model/enums.dart';
 
@@ -80,6 +81,28 @@ class Loan {
       status: status,
       repaidAmount: repaidAmount,
       updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Convert this Loan to a Companion for updating an existing row.
+  /// Requires a non-null id. Only writes fields explicitly set as Value(...)
+  /// (createdAt is omitted so the original value is preserved).
+  db.LoansCompanion toUpdateCompanion() {
+    assert(
+      id != null,
+      'toUpdateCompanion() requires a non-null id.',
+    );
+    return db.LoansCompanion(
+      id: Value(id!),
+      type: Value(type),
+      counterpartyName: Value(counterpartyName),
+      amount: Value(amount),
+      description: Value(description),
+      startDate: Value(startDate),
+      dueDate: Value(dueDate),
+      status: Value(status),
+      repaidAmount: Value(repaidAmount),
+      updatedAt: Value(DateTime.now()),
     );
   }
 

--- a/lib/data/model/loan.dart
+++ b/lib/data/model/loan.dart
@@ -80,6 +80,7 @@ class Loan {
       dueDate: dueDate,
       status: status,
       repaidAmount: repaidAmount,
+      createdAt: createdAt,
       updatedAt: DateTime.now(),
     );
   }

--- a/lib/data/model/loan.dart
+++ b/lib/data/model/loan.dart
@@ -1,7 +1,8 @@
+import 'package:rocket_pocket/data/local/database.dart' as db;
 import 'package:rocket_pocket/data/model/enums.dart';
 
 class Loan {
-  final int id;
+  int? id;
   final LoanType type;
   final String counterpartyName;
   final double amount;
@@ -13,7 +14,7 @@ class Loan {
   final DateTime createdAt;
 
   Loan({
-    required this.id,
+    this.id,
     required this.type,
     required this.counterpartyName,
     required this.amount,
@@ -24,4 +25,83 @@ class Loan {
     required this.repaidAmount,
     required this.createdAt,
   });
+
+  Loan copyWith({
+    int? id,
+    LoanType? type,
+    String? counterpartyName,
+    double? amount,
+    String? description,
+    DateTime? startDate,
+    DateTime? dueDate,
+    LoanStatus? status,
+    double? repaidAmount,
+    DateTime? createdAt,
+  }) {
+    return Loan(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      counterpartyName: counterpartyName ?? this.counterpartyName,
+      amount: amount ?? this.amount,
+      description: description ?? this.description,
+      startDate: startDate ?? this.startDate,
+      dueDate: dueDate ?? this.dueDate,
+      status: status ?? this.status,
+      repaidAmount: repaidAmount ?? this.repaidAmount,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  static Loan fromDb(db.Loan row) {
+    return Loan(
+      id: row.id,
+      type: row.type,
+      counterpartyName: row.counterpartyName,
+      amount: row.amount,
+      description: row.description,
+      startDate: row.startDate,
+      dueDate: row.dueDate,
+      status: row.status,
+      repaidAmount: row.repaidAmount,
+      createdAt: row.createdAt,
+    );
+  }
+
+  /// Convert this Loan to a Companion for inserting a new row.
+  /// Uses Value.absent() for id so the database auto-increments it.
+  db.LoansCompanion toInsertCompanion() {
+    return db.LoansCompanion.insert(
+      type: type,
+      counterpartyName: counterpartyName,
+      amount: amount,
+      description: description,
+      startDate: startDate,
+      dueDate: dueDate,
+      status: status,
+      repaidAmount: repaidAmount,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// Convert this Loan to a database row for updates.
+  /// Requires a non-null id (the row must already exist).
+  db.Loan toDb() {
+    assert(
+      id != null,
+      'toDb() requires a non-null id. Use toInsertCompanion() for new loans.',
+    );
+    return db.Loan(
+      id: id!,
+      type: type,
+      counterpartyName: counterpartyName,
+      amount: amount,
+      description: description,
+      startDate: startDate,
+      dueDate: dueDate,
+      status: status,
+      repaidAmount: repaidAmount,
+      createdAt: createdAt,
+      updatedAt: DateTime.now(),
+    );
+  }
 }

--- a/lib/data/model/loan.dart
+++ b/lib/data/model/loan.dart
@@ -80,7 +80,7 @@ class Loan {
       dueDate: dueDate,
       status: status,
       repaidAmount: repaidAmount,
-      createdAt: createdAt,
+      createdAt: Value(createdAt),
       updatedAt: DateTime.now(),
     );
   }

--- a/lib/repositories/loan_repository.dart
+++ b/lib/repositories/loan_repository.dart
@@ -104,7 +104,7 @@ class LoanRepository {
     try {
       return await (db.update(db.loans)..where(
         (tbl) => tbl.id.equals(id),
-      )).write(LoansCompanion(status: Value(status.name as LoanStatus)));
+      )).write(LoansCompanion(status: Value(status)));
     } catch (e, stack) {
       DatabaseError('Failed to update loan status', stack).throwError();
     }

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -144,6 +144,12 @@ class NavigationHelper {
                 },
               ),
               GoRoute(
+                path: Paths.addLoan,
+                pageBuilder: (context, state) {
+                  return getPage(child: AddLoanScreen(), state: state);
+                },
+              ),
+              GoRoute(
                 path: Paths.loanDetails,
                 pageBuilder: (context, state) {
                   final loan = state.extra;

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -175,6 +175,19 @@ class NavigationHelper {
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),
+              GoRoute(
+                path: Paths.editLoan,
+                pageBuilder: (context, state) {
+                  final loan = state.extra;
+                  if (loan is Loan) {
+                    return getPage(
+                      child: EditLoanScreen(loan: loan),
+                      state: state,
+                    );
+                  }
+                  return getPage(child: LoanScreen(), state: state);
+                },
+              ),
             ],
           ),
 

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -162,6 +162,19 @@ class NavigationHelper {
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),
+              GoRoute(
+                path: Paths.addRepayment,
+                pageBuilder: (context, state) {
+                  final loan = state.extra;
+                  if (loan is Loan) {
+                    return getPage(
+                      child: AddRepaymentScreen(loan: loan),
+                      state: state,
+                    );
+                  }
+                  return getPage(child: LoanScreen(), state: state);
+                },
+              ),
             ],
           ),
 

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -24,6 +24,8 @@ class NavigationHelper {
       GlobalKey<NavigatorState>(debugLabel: 'budgetNavigationKey');
   final GlobalKey<NavigatorState> settingsNavigationKey =
       GlobalKey<NavigatorState>(debugLabel: 'settingsNavigationKey');
+  final GlobalKey<NavigatorState> loanNavigationKey =
+      GlobalKey<NavigatorState>(debugLabel: 'loanNavigationKey');
 
   factory NavigationHelper() {
     return _instance;
@@ -138,6 +140,19 @@ class NavigationHelper {
                 path: Paths.settings,
                 pageBuilder: (context, state) {
                   return getPage(child: SettingsScreen(), state: state);
+                },
+              ),
+            ],
+          ),
+
+          // Loan Branch
+          StatefulShellBranch(
+            navigatorKey: loanNavigationKey,
+            routes: [
+              GoRoute(
+                path: Paths.loan,
+                pageBuilder: (context, state) {
+                  return getPage(child: LoanScreen(), state: state);
                 },
               ),
             ],

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
 import 'package:rocket_pocket/data/model/pocket.dart';
 import 'package:rocket_pocket/router/get_page.dart';
 import 'package:rocket_pocket/router/paths.dart';
@@ -139,6 +140,19 @@ class NavigationHelper {
               GoRoute(
                 path: Paths.loan,
                 pageBuilder: (context, state) {
+                  return getPage(child: LoanScreen(), state: state);
+                },
+              ),
+              GoRoute(
+                path: Paths.loanDetails,
+                pageBuilder: (context, state) {
+                  final loan = state.extra;
+                  if (loan is Loan) {
+                    return getPage(
+                      child: LoanDetailScreen(loan: loan),
+                      state: state,
+                    );
+                  }
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -152,13 +152,26 @@ class NavigationHelper {
               GoRoute(
                 path: Paths.loanDetails,
                 pageBuilder: (context, state) {
-                  final loan = state.extra;
-                  if (loan is Loan) {
+                  final extra = state.extra;
+                  if (extra is Loan) {
                     return getPage(
-                      child: LoanDetailScreen(loan: loan),
+                      child: LoanDetailScreen(loan: extra),
                       state: state,
                     );
                   }
+
+                  // Fallback: parse loanId from path and let LoanDetailScreen
+                  // fetch the loan, mirroring the pocket routes pattern.
+                  final loanIdParam = state.pathParameters['loanId'];
+                  final loanId =
+                      loanIdParam != null ? int.tryParse(loanIdParam) : null;
+                  if (loanId != null) {
+                    return getPage(
+                      child: LoanDetailScreen(loanId: loanId),
+                      state: state,
+                    );
+                  }
+
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),
@@ -172,6 +185,19 @@ class NavigationHelper {
                       state: state,
                     );
                   }
+
+                  // Fallback: navigate to the loan detail screen where the
+                  // user can retry adding a repayment with the full context.
+                  final loanIdParam = state.pathParameters['loanId'];
+                  final loanId =
+                      loanIdParam != null ? int.tryParse(loanIdParam) : null;
+                  if (loanId != null) {
+                    return getPage(
+                      child: LoanDetailScreen(loanId: loanId),
+                      state: state,
+                    );
+                  }
+
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),
@@ -185,6 +211,19 @@ class NavigationHelper {
                       state: state,
                     );
                   }
+
+                  // Fallback: navigate to the loan detail screen where the
+                  // user can retry editing with the full context.
+                  final loanIdParam = state.pathParameters['loanId'];
+                  final loanId =
+                      loanIdParam != null ? int.tryParse(loanIdParam) : null;
+                  if (loanId != null) {
+                    return getPage(
+                      child: LoanDetailScreen(loanId: loanId),
+                      state: state,
+                    );
+                  }
+
                   return getPage(child: LoanScreen(), state: state);
                 },
               ),

--- a/lib/router/navigation_helper.dart
+++ b/lib/router/navigation_helper.dart
@@ -132,19 +132,6 @@ class NavigationHelper {
             ],
           ),
 
-          // Settings Branch
-          StatefulShellBranch(
-            navigatorKey: settingsNavigationKey,
-            routes: [
-              GoRoute(
-                path: Paths.settings,
-                pageBuilder: (context, state) {
-                  return getPage(child: SettingsScreen(), state: state);
-                },
-              ),
-            ],
-          ),
-
           // Loan Branch
           StatefulShellBranch(
             navigatorKey: loanNavigationKey,
@@ -153,6 +140,19 @@ class NavigationHelper {
                 path: Paths.loan,
                 pageBuilder: (context, state) {
                   return getPage(child: LoanScreen(), state: state);
+                },
+              ),
+            ],
+          ),
+
+          // Settings Branch
+          StatefulShellBranch(
+            navigatorKey: settingsNavigationKey,
+            routes: [
+              GoRoute(
+                path: Paths.settings,
+                pageBuilder: (context, state) {
+                  return getPage(child: SettingsScreen(), state: state);
                 },
               ),
             ],

--- a/lib/router/paths.dart
+++ b/lib/router/paths.dart
@@ -1,28 +1,39 @@
-class Paths {
+abstract final class Paths {
+  // ── Root ────────────────────────────────────────────────────────────────────
   static const String root = '/';
+
+  // ── Dashboard ───────────────────────────────────────────────────────────────
   static const String dashboard = '/dashboard';
-  static const String createPocket = '$dashboard/create-Pocket';
+  static const String createPocket = '$dashboard/create-pocket';
   static const String pocketDetails = '$dashboard/pocket/:pocketId';
-  static const String pocketTransactions = '$pocketDetails/Pocket-transactions';
+  static const String pocketTransactions = '$pocketDetails/pocket-transactions';
   static const String editPocket = '$pocketDetails/edit';
 
-  /// Returns the concrete path for a given pocket id.
   static String pocketDetailsRoute(int pocketId) =>
       '$dashboard/pocket/$pocketId';
-
+  static String pocketTransactionsRoute(int pocketId) =>
+      '$dashboard/pocket/$pocketId/pocket-transactions';
   static String editPocketRoute(int pocketId) =>
       '$dashboard/pocket/$pocketId/edit';
 
+  // ── Transaction ─────────────────────────────────────────────────────────────
   static const String transaction = '/transaction';
   static const String addTransaction = '$transaction/add';
 
+  // ── Budget ──────────────────────────────────────────────────────────────────
   static const String budget = '/budget';
-  static const String settings = '/settings';
+
+  // ── Loan ────────────────────────────────────────────────────────────────────
   static const String loan = '/loan';
   static const String addLoan = '$loan/add';
   static const String loanDetails = '$loan/:loanId';
+  static const String editLoan = '$loan/:loanId/edit';
   static const String addRepayment = '$loan/:loanId/repayment';
 
   static String loanDetailsRoute(int loanId) => '$loan/$loanId';
+  static String editLoanRoute(int loanId) => '$loan/$loanId/edit';
   static String addRepaymentRoute(int loanId) => '$loan/$loanId/repayment';
+
+  // ── Settings ────────────────────────────────────────────────────────────────
+  static const String settings = '/settings';
 }

--- a/lib/router/paths.dart
+++ b/lib/router/paths.dart
@@ -19,4 +19,7 @@ class Paths {
   static const String budget = '/budget';
   static const String settings = '/settings';
   static const String loan = '/loan';
+  static const String loanDetails = '$loan/:loanId';
+
+  static String loanDetailsRoute(int loanId) => '$loan/$loanId';
 }

--- a/lib/router/paths.dart
+++ b/lib/router/paths.dart
@@ -21,6 +21,8 @@ class Paths {
   static const String loan = '/loan';
   static const String addLoan = '$loan/add';
   static const String loanDetails = '$loan/:loanId';
+  static const String addRepayment = '$loan/:loanId/repayment';
 
   static String loanDetailsRoute(int loanId) => '$loan/$loanId';
+  static String addRepaymentRoute(int loanId) => '$loan/$loanId/repayment';
 }

--- a/lib/router/paths.dart
+++ b/lib/router/paths.dart
@@ -19,6 +19,7 @@ class Paths {
   static const String budget = '/budget';
   static const String settings = '/settings';
   static const String loan = '/loan';
+  static const String addLoan = '$loan/add';
   static const String loanDetails = '$loan/:loanId';
 
   static String loanDetailsRoute(int loanId) => '$loan/$loanId';

--- a/lib/router/paths.dart
+++ b/lib/router/paths.dart
@@ -18,4 +18,5 @@ class Paths {
 
   static const String budget = '/budget';
   static const String settings = '/settings';
+  static const String loan = '/loan';
 }

--- a/lib/screens/loan/add_loan_screen.dart
+++ b/lib/screens/loan/add_loan_screen.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/viewmodels/add_loan_view_model.dart';
+
+class AddLoanScreen extends ConsumerWidget {
+  const AddLoanScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModelAsync = ref.watch(addLoanViewModelProvider);
+
+    return Scaffold(
+      body: viewModelAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (state) => _AddLoanForm(state: state),
+      ),
+    );
+  }
+}
+
+class _AddLoanForm extends ConsumerWidget {
+  final AddLoanState state;
+
+  const _AddLoanForm({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(addLoanViewModelProvider.notifier);
+    final theme = Theme.of(context);
+
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          pinned: true,
+          floating: true,
+          expandedHeight: 120,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.pop(),
+          ),
+          flexibleSpace: const FlexibleSpaceBar(
+            title: Text('Add Loan'),
+            titlePadding: EdgeInsets.only(left: 56, bottom: 16),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Loan type ──────────────────────────────────────────
+                Text('Type', style: theme.textTheme.labelLarge),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: SegmentedButton<LoanType>(
+                    showSelectedIcon: false,
+                    segments: const [
+                      ButtonSegment(
+                        value: LoanType.given,
+                        label: Text('Loan Given'),
+                        icon: Icon(Icons.call_made),
+                      ),
+                      ButtonSegment(
+                        value: LoanType.taken,
+                        label: Text('Loan Taken'),
+                        icon: Icon(Icons.call_received),
+                      ),
+                    ],
+                    selected: {state.selectedType},
+                    onSelectionChanged: (v) => notifier.setType(v.first),
+                  ),
+                ),
+
+                const SizedBox(height: 24),
+
+                // ── Counterparty name ──────────────────────────────────
+                TextFormField(
+                  initialValue: state.counterpartyName,
+                  decoration: const InputDecoration(
+                    labelText: 'Counterparty Name',
+                    hintText: 'Person or organization',
+                    border: OutlineInputBorder(),
+                    icon: Icon(Icons.person_outline),
+                  ),
+                  textCapitalization: TextCapitalization.words,
+                  onChanged: notifier.setCounterpartyName,
+                ),
+
+                const SizedBox(height: 16),
+
+                // ── Amount ─────────────────────────────────────────────
+                TextFormField(
+                  decoration: const InputDecoration(
+                    labelText: 'Amount',
+                    border: OutlineInputBorder(),
+                    icon: Icon(Icons.payments_outlined),
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  onChanged: (v) => notifier.setAmount(double.tryParse(v) ?? 0),
+                ),
+
+                const SizedBox(height: 16),
+
+                // ── Description / notes ────────────────────────────────
+                TextFormField(
+                  initialValue: state.description,
+                  decoration: const InputDecoration(
+                    labelText: 'Notes (optional)',
+                    border: OutlineInputBorder(),
+                    icon: Icon(Icons.notes_outlined),
+                  ),
+                  maxLines: 2,
+                  textCapitalization: TextCapitalization.sentences,
+                  onChanged: notifier.setDescription,
+                ),
+
+                const SizedBox(height: 24),
+
+                // ── Dates ──────────────────────────────────────────────
+                Text('Duration', style: theme.textTheme.labelLarge),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _DateField(
+                        label: 'Start Date',
+                        icon: Icons.calendar_today_outlined,
+                        date: state.startDate,
+                        onPicked: notifier.setStartDate,
+                        firstDate: DateTime(2000),
+                        lastDate: DateTime(2100),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _DateField(
+                        label: 'Due Date',
+                        icon: Icons.event_outlined,
+                        date: state.dueDate,
+                        onPicked: notifier.setDueDate,
+                        firstDate: state.startDate,
+                        lastDate: DateTime(2100),
+                      ),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 32),
+
+                // ── Submit ─────────────────────────────────────────────
+                FilledButton.icon(
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(50),
+                  ),
+                  icon: const Icon(Icons.check),
+                  label: const Text('Save Loan'),
+                  onPressed:
+                      state.isValid
+                          ? () async {
+                            await ref
+                                .read(addLoanViewModelProvider.notifier)
+                                .submit();
+                            if (context.mounted) context.pop();
+                          }
+                          : null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DateField extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final DateTime date;
+  final ValueChanged<DateTime> onPicked;
+  final DateTime firstDate;
+  final DateTime lastDate;
+
+  const _DateField({
+    required this.label,
+    required this.icon,
+    required this.date,
+    required this.onPicked,
+    required this.firstDate,
+    required this.lastDate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        final picked = await showDatePicker(
+          context: context,
+          initialDate: date,
+          firstDate: firstDate,
+          lastDate: lastDate,
+        );
+        if (picked != null) onPicked(picked);
+      },
+      borderRadius: BorderRadius.circular(4),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          icon: Icon(icon),
+        ),
+        child: Text(
+          '${date.year}-'
+          '${date.month.toString().padLeft(2, '0')}-'
+          '${date.day.toString().padLeft(2, '0')}',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/loan/add_repayment_screen.dart
+++ b/lib/screens/loan/add_repayment_screen.dart
@@ -181,7 +181,7 @@ class _AddRepaymentForm extends ConsumerWidget {
                   ),
                   onChanged: (v) {
                     final parsed = double.tryParse(v) ?? 0;
-                    final clamped = parsed < 0
+                    double clamped = parsed < 0
                         ? 0
                         : (parsed > remaining ? remaining : parsed);
                     notifier.setAmount(clamped);

--- a/lib/screens/loan/add_repayment_screen.dart
+++ b/lib/screens/loan/add_repayment_screen.dart
@@ -172,11 +172,20 @@ class _AddRepaymentForm extends ConsumerWidget {
                     hintText: 'Max: ${currencyFormat.format(remaining)}',
                     border: const OutlineInputBorder(),
                     icon: const Icon(Icons.payments_outlined),
+                    errorText: state.amount > remaining
+                        ? 'Amount cannot exceed remaining (${currencyFormat.format(remaining)})'
+                        : null,
                   ),
                   keyboardType: const TextInputType.numberWithOptions(
                     decimal: true,
                   ),
-                  onChanged: (v) => notifier.setAmount(double.tryParse(v) ?? 0),
+                  onChanged: (v) {
+                    final parsed = double.tryParse(v) ?? 0;
+                    final clamped = parsed < 0
+                        ? 0
+                        : (parsed > remaining ? remaining : parsed);
+                    notifier.setAmount(clamped);
+                  },
                 ),
 
                 const SizedBox(height: 16),

--- a/lib/screens/loan/add_repayment_screen.dart
+++ b/lib/screens/loan/add_repayment_screen.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/data/model/pocket.dart';
+import 'package:rocket_pocket/viewmodels/add_repayment_view_model.dart';
+
+class AddRepaymentScreen extends ConsumerWidget {
+  final Loan loan;
+
+  const AddRepaymentScreen({super.key, required this.loan});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModelAsync = ref.watch(addRepaymentViewModelProvider);
+
+    return Scaffold(
+      body: viewModelAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (state) => _AddRepaymentForm(loan: loan, state: state),
+      ),
+    );
+  }
+}
+
+class _AddRepaymentForm extends ConsumerWidget {
+  final Loan loan;
+  final AddRepaymentState state;
+
+  const _AddRepaymentForm({required this.loan, required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(addRepaymentViewModelProvider.notifier);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final isCollection = loan.type == LoanType.given;
+    final title = isCollection ? 'Record Collection' : 'Record Repayment';
+    final remaining = loan.amount - loan.repaidAmount;
+    final currencyFormat = NumberFormat('#,##0.##');
+
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          pinned: true,
+          floating: true,
+          expandedHeight: 120,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.pop(),
+          ),
+          flexibleSpace: FlexibleSpaceBar(
+            title: Text(title),
+            titlePadding: const EdgeInsets.only(left: 56, bottom: 16),
+          ),
+        ),
+
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ── Loan summary card ───────────────────────────────────
+                Card(
+                  color: colorScheme.secondaryContainer,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        CircleAvatar(
+                          backgroundColor: colorScheme.secondary,
+                          foregroundColor: colorScheme.onSecondary,
+                          radius: 22,
+                          child: Text(
+                            loan.counterpartyName.isNotEmpty
+                                ? loan.counterpartyName[0].toUpperCase()
+                                : '?',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                loan.counterpartyName,
+                                style: theme.textTheme.titleSmall?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: colorScheme.onSecondaryContainer,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                isCollection
+                                    ? 'Outstanding: ${currencyFormat.format(remaining)}'
+                                    : 'Remaining: ${currencyFormat.format(remaining)}',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSecondaryContainer,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: 24),
+
+                // ── Pocket selector ─────────────────────────────────────
+                Text('Pocket', style: theme.textTheme.labelLarge),
+                const SizedBox(height: 8),
+                if (state.pockets.isEmpty)
+                  Text(
+                    'No pockets available.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.error,
+                    ),
+                  )
+                else
+                  DropdownButtonFormField<Pocket>(
+                    value: state.selectedPocket,
+                    decoration: InputDecoration(
+                      border: const OutlineInputBorder(),
+                      icon: Icon(
+                        isCollection
+                            ? Icons.account_balance_wallet_outlined
+                            : Icons.account_balance_wallet_outlined,
+                      ),
+                      hintText: 'Select pocket',
+                    ),
+                    items:
+                        state.pockets.map((p) {
+                          return DropdownMenuItem(
+                            value: p,
+                            child: Row(
+                              children: [
+                                Text(p.emoticon),
+                                const SizedBox(width: 8),
+                                Text(p.name),
+                                const SizedBox(width: 4),
+                                Text(
+                                  '(${p.currency} ${currencyFormat.format(p.balance)})',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }).toList(),
+                    onChanged: (p) {
+                      if (p != null) notifier.setSelectedPocket(p);
+                    },
+                  ),
+
+                const SizedBox(height: 16),
+
+                // ── Amount ──────────────────────────────────────────────
+                TextFormField(
+                  decoration: InputDecoration(
+                    labelText: 'Amount',
+                    hintText: 'Max: ${currencyFormat.format(remaining)}',
+                    border: const OutlineInputBorder(),
+                    icon: const Icon(Icons.payments_outlined),
+                  ),
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  onChanged: (v) => notifier.setAmount(double.tryParse(v) ?? 0),
+                ),
+
+                const SizedBox(height: 16),
+
+                // ── Description ─────────────────────────────────────────
+                TextFormField(
+                  decoration: const InputDecoration(
+                    labelText: 'Notes (optional)',
+                    border: OutlineInputBorder(),
+                    icon: Icon(Icons.notes_outlined),
+                  ),
+                  maxLines: 2,
+                  textCapitalization: TextCapitalization.sentences,
+                  onChanged: notifier.setDescription,
+                ),
+
+                const SizedBox(height: 16),
+
+                // ── Date picker ─────────────────────────────────────────
+                _DateTimeField(
+                  label: 'Date',
+                  dateTime: state.date,
+                  onPicked: notifier.setDate,
+                ),
+
+                const SizedBox(height: 32),
+
+                // ── Submit ──────────────────────────────────────────────
+                FilledButton.icon(
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(50),
+                  ),
+                  icon: const Icon(Icons.check),
+                  label: Text(title),
+                  onPressed:
+                      state.isValid
+                          ? () async {
+                            await ref
+                                .read(addRepaymentViewModelProvider.notifier)
+                                .submit(loan);
+                            if (context.mounted) context.pop();
+                          }
+                          : null,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DateTimeField extends StatelessWidget {
+  final String label;
+  final DateTime dateTime;
+  final ValueChanged<DateTime> onPicked;
+
+  const _DateTimeField({
+    required this.label,
+    required this.dateTime,
+    required this.onPicked,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final formatter = DateFormat('yyyy-MM-dd HH:mm');
+    return InkWell(
+      onTap: () async {
+        final pickedDate = await showDatePicker(
+          context: context,
+          initialDate: dateTime,
+          firstDate: DateTime(2000),
+          lastDate: DateTime(2100),
+        );
+        if (pickedDate == null || !context.mounted) return;
+
+        final pickedTime = await showTimePicker(
+          context: context,
+          initialTime: TimeOfDay.fromDateTime(dateTime),
+        );
+        if (pickedTime == null) return;
+
+        onPicked(
+          DateTime(
+            pickedDate.year,
+            pickedDate.month,
+            pickedDate.day,
+            pickedTime.hour,
+            pickedTime.minute,
+          ),
+        );
+      },
+      borderRadius: BorderRadius.circular(4),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          icon: const Icon(Icons.calendar_today_outlined),
+        ),
+        child: Text(formatter.format(dateTime)),
+      ),
+    );
+  }
+}

--- a/lib/screens/loan/edit_loan_screen.dart
+++ b/lib/screens/loan/edit_loan_screen.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/viewmodels/loan_view_model.dart';
+
+class EditLoanScreen extends ConsumerStatefulWidget {
+  final Loan loan;
+
+  const EditLoanScreen({super.key, required this.loan});
+
+  @override
+  ConsumerState<EditLoanScreen> createState() => _EditLoanScreenState();
+}
+
+class _EditLoanScreenState extends ConsumerState<EditLoanScreen> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _amountController;
+  late final TextEditingController _descriptionController;
+  late LoanStatus _status;
+  late DateTime _startDate;
+  late DateTime _dueDate;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(
+      text: widget.loan.counterpartyName,
+    );
+    _amountController = TextEditingController(
+      text: widget.loan.amount.toString(),
+    );
+    _descriptionController = TextEditingController(
+      text: widget.loan.description,
+    );
+    _status = widget.loan.status;
+    _startDate = widget.loan.startDate;
+    _dueDate = widget.loan.dueDate;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _amountController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  bool get _isValid =>
+      _nameController.text.trim().isNotEmpty &&
+      (double.tryParse(_amountController.text) ?? 0) > 0;
+
+  Future<void> _save() async {
+    if (!_isValid) return;
+    setState(() => _saving = true);
+    try {
+      final updated = widget.loan.copyWith(
+        counterpartyName: _nameController.text.trim(),
+        amount: double.parse(_amountController.text),
+        description: _descriptionController.text.trim(),
+        status: _status,
+        startDate: _startDate,
+        dueDate: _dueDate,
+      );
+      await ref
+          .read(loanViewModelProvider.notifier)
+          .updateLoan(updated.toUpdateCompanion());
+      if (mounted) context.pop();
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to save. Please try again.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            pinned: true,
+            floating: true,
+            expandedHeight: 120,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.pop(),
+            ),
+            flexibleSpace: const FlexibleSpaceBar(
+              title: Text('Edit Loan'),
+              titlePadding: EdgeInsets.only(left: 56, bottom: 16),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // ── Loan type (read-only) ──────────────────────────
+                  Row(
+                    children: [
+                      Icon(
+                        widget.loan.type == LoanType.given
+                            ? Icons.call_made
+                            : Icons.call_received,
+                        size: 20,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        widget.loan.type == LoanType.given
+                            ? 'Loan Given'
+                            : 'Loan Taken',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // ── Counterparty name ──────────────────────────────
+                  TextField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(
+                      labelText: 'Counterparty Name',
+                      hintText: 'Person or organization',
+                      border: OutlineInputBorder(),
+                      icon: Icon(Icons.person_outline),
+                    ),
+                    textCapitalization: TextCapitalization.words,
+                    onChanged: (_) => setState(() {}),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // ── Amount ─────────────────────────────────────────
+                  TextField(
+                    controller: _amountController,
+                    decoration: const InputDecoration(
+                      labelText: 'Amount',
+                      border: OutlineInputBorder(),
+                      icon: Icon(Icons.payments_outlined),
+                    ),
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+
+                  const SizedBox(height: 16),
+
+                  // ── Description ────────────────────────────────────
+                  TextField(
+                    controller: _descriptionController,
+                    decoration: const InputDecoration(
+                      labelText: 'Notes (optional)',
+                      border: OutlineInputBorder(),
+                      icon: Icon(Icons.notes_outlined),
+                    ),
+                    maxLines: 2,
+                    textCapitalization: TextCapitalization.sentences,
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // ── Status ─────────────────────────────────────────
+                  Text('Status', style: theme.textTheme.labelLarge),
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<LoanStatus>(
+                    value: _status,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      icon: Icon(Icons.flag_outlined),
+                    ),
+                    items: LoanStatus.values.map((s) {
+                      return DropdownMenuItem(
+                        value: s,
+                        child: Text(_statusLabel(s)),
+                      );
+                    }).toList(),
+                    onChanged: (v) {
+                      if (v != null) setState(() => _status = v);
+                    },
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // ── Dates ──────────────────────────────────────────
+                  Text('Duration', style: theme.textTheme.labelLarge),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _DateField(
+                          label: 'Start Date',
+                          icon: Icons.calendar_today_outlined,
+                          date: _startDate,
+                          firstDate: DateTime(2000),
+                          lastDate: DateTime(2100),
+                          onPicked: (d) => setState(() => _startDate = d),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _DateField(
+                          label: 'Due Date',
+                          icon: Icons.event_outlined,
+                          date: _dueDate,
+                          firstDate: _startDate,
+                          lastDate: DateTime(2100),
+                          onPicked: (d) => setState(() => _dueDate = d),
+                        ),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 32),
+
+                  // ── Save ───────────────────────────────────────────
+                  FilledButton.icon(
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(50),
+                    ),
+                    icon:
+                        _saving
+                            ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                color: Colors.white,
+                                strokeWidth: 2,
+                              ),
+                            )
+                            : const Icon(Icons.save),
+                    label: const Text('Save Changes'),
+                    onPressed: (_isValid && !_saving) ? _save : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _statusLabel(LoanStatus s) => switch (s) {
+    LoanStatus.ongoing => 'Ongoing',
+    LoanStatus.completed => 'Completed',
+    LoanStatus.overdue => 'Overdue',
+    LoanStatus.cancelled => 'Cancelled',
+  };
+}
+
+class _DateField extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final DateTime date;
+  final DateTime firstDate;
+  final DateTime lastDate;
+  final ValueChanged<DateTime> onPicked;
+
+  const _DateField({
+    required this.label,
+    required this.icon,
+    required this.date,
+    required this.firstDate,
+    required this.lastDate,
+    required this.onPicked,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        final picked = await showDatePicker(
+          context: context,
+          initialDate: date,
+          firstDate: firstDate,
+          lastDate: lastDate,
+        );
+        if (picked != null) onPicked(picked);
+      },
+      borderRadius: BorderRadius.circular(4),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          icon: Icon(icon),
+        ),
+        child: Text(
+          '${date.year}-'
+          '${date.month.toString().padLeft(2, '0')}-'
+          '${date.day.toString().padLeft(2, '0')}',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/loan/loan_card.dart
+++ b/lib/screens/loan/loan_card.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+
+class LoanCard extends StatelessWidget {
+  final Loan loan;
+  final VoidCallback? onTap;
+
+  const LoanCard({super.key, required this.loan, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final remaining = loan.amount - loan.repaidAmount;
+    final progress =
+        loan.amount > 0
+            ? (loan.repaidAmount / loan.amount).clamp(0.0, 1.0)
+            : 0.0;
+    final isOverdue =
+        loan.status == LoanStatus.ongoing &&
+        loan.dueDate.isBefore(DateTime.now());
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ── Header row ────────────────────────────────────────────
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Avatar
+                  CircleAvatar(
+                    radius: 22,
+                    backgroundColor: colorScheme.primaryContainer,
+                    child: Text(
+                      loan.counterpartyName.isNotEmpty
+                          ? loan.counterpartyName[0].toUpperCase()
+                          : '?',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Name + description
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          loan.counterpartyName,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (loan.description.isNotEmpty) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            loan.description,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  // Status chip
+                  _StatusChip(status: loan.status, isOverdue: isOverdue),
+                ],
+              ),
+
+              const SizedBox(height: 14),
+
+              // ── Amount row ────────────────────────────────────────────
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Total',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      Text(
+                        loan.amount.toStringAsFixed(2),
+                        style: theme.textTheme.titleSmall,
+                      ),
+                    ],
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        'Repaid',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      Text(
+                        loan.repaidAmount.toStringAsFixed(2),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: colorScheme.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        'Remaining',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      Text(
+                        remaining.toStringAsFixed(2),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: isOverdue ? colorScheme.error : null,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+
+              const SizedBox(height: 10),
+
+              // ── Progress bar ──────────────────────────────────────────
+              LinearProgressIndicator(
+                value: progress,
+                borderRadius: BorderRadius.circular(4),
+                backgroundColor: colorScheme.surfaceContainerHighest,
+                color:
+                    loan.status == LoanStatus.completed
+                        ? colorScheme.primary
+                        : isOverdue
+                        ? colorScheme.error
+                        : colorScheme.primary,
+              ),
+
+              const SizedBox(height: 10),
+
+              // ── Due date row ──────────────────────────────────────────
+              Row(
+                children: [
+                  Icon(
+                    Icons.calendar_today_outlined,
+                    size: 13,
+                    color:
+                        isOverdue
+                            ? colorScheme.error
+                            : colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    'Due ${_formatDate(loan.dueDate)}',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color:
+                          isOverdue
+                              ? colorScheme.error
+                              : colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime dt) =>
+      '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+}
+
+class _StatusChip extends StatelessWidget {
+  final LoanStatus status;
+  final bool isOverdue;
+
+  const _StatusChip({required this.status, required this.isOverdue});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final (label, bg, fg) = switch (status) {
+      LoanStatus.ongoing when isOverdue => (
+        'Overdue',
+        colorScheme.errorContainer,
+        colorScheme.onErrorContainer,
+      ),
+      LoanStatus.ongoing => (
+        'Ongoing',
+        colorScheme.secondaryContainer,
+        colorScheme.onSecondaryContainer,
+      ),
+      LoanStatus.completed => (
+        'Completed',
+        colorScheme.primaryContainer,
+        colorScheme.onPrimaryContainer,
+      ),
+      LoanStatus.overdue => (
+        'Overdue',
+        colorScheme.errorContainer,
+        colorScheme.onErrorContainer,
+      ),
+      LoanStatus.cancelled => (
+        'Cancelled',
+        colorScheme.surfaceContainerHighest,
+        colorScheme.onSurfaceVariant,
+      ),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(color: fg),
+      ),
+    );
+  }
+}

--- a/lib/screens/loan/loan_detail_header.dart
+++ b/lib/screens/loan/loan_detail_header.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+
+class LoanDetailHeader extends StatelessWidget {
+  final Loan loan;
+  final double progress;
+  final double remaining;
+  final bool isOverdue;
+  final Color foregroundColor;
+
+  const LoanDetailHeader({
+    super.key,
+    required this.loan,
+    required this.progress,
+    required this.remaining,
+    required this.isOverdue,
+    required this.foregroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = TextStyle(color: foregroundColor);
+    final subtleStyle = TextStyle(
+      color: foregroundColor.withValues(alpha: 0.75),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        // Avatar + name
+        Row(
+          children: [
+            CircleAvatar(
+              radius: 28,
+              backgroundColor: foregroundColor.withValues(alpha: 0.2),
+              child: Text(
+                loan.counterpartyName.isNotEmpty
+                    ? loan.counterpartyName[0].toUpperCase()
+                    : '?',
+                style: TextStyle(
+                  color: foregroundColor,
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    loan.counterpartyName,
+                    style: textStyle.copyWith(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    loan.type == LoanType.given ? 'Loan Given' : 'Loan Taken',
+                    style: subtleStyle.copyWith(fontSize: 13),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+
+        const SizedBox(height: 20),
+
+        // Total amount
+        Text('Total Amount', style: subtleStyle.copyWith(fontSize: 12)),
+        Text(
+          loan.amount.toStringAsFixed(2),
+          style: textStyle.copyWith(fontSize: 28, fontWeight: FontWeight.bold),
+        ),
+
+        const SizedBox(height: 12),
+
+        // Progress bar
+        LinearProgressIndicator(
+          value: progress,
+          borderRadius: BorderRadius.circular(4),
+          backgroundColor: foregroundColor.withValues(alpha: 0.2),
+          valueColor: AlwaysStoppedAnimation<Color>(foregroundColor),
+          minHeight: 6,
+        ),
+
+        const SizedBox(height: 8),
+
+        // Repaid / remaining row
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Repaid: ${loan.repaidAmount.toStringAsFixed(2)}',
+              style: subtleStyle.copyWith(fontSize: 12),
+            ),
+            Text(
+              'Remaining: ${remaining.toStringAsFixed(2)}',
+              style: textStyle.copyWith(
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/loan/loan_detail_info_card.dart
+++ b/lib/screens/loan/loan_detail_info_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+
+class LoanDetailInfoCard extends StatelessWidget {
+  final Loan loan;
+  final bool isOverdue;
+
+  const LoanDetailInfoCard({
+    super.key,
+    required this.loan,
+    required this.isOverdue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            _InfoRow(
+              icon: Icons.calendar_today_outlined,
+              label: 'Start Date',
+              value: _formatDate(loan.startDate),
+            ),
+            const Divider(height: 20),
+            _InfoRow(
+              icon: Icons.event_outlined,
+              label: 'Due Date',
+              value: _formatDate(loan.dueDate),
+              valueColor: isOverdue ? colorScheme.error : null,
+            ),
+            if (loan.description.isNotEmpty) ...[
+              const Divider(height: 20),
+              _InfoRow(
+                icon: Icons.notes_outlined,
+                label: 'Notes',
+                value: loan.description,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _formatDate(DateTime dt) =>
+      '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+}
+
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.valueColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 18, color: theme.colorScheme.onSurfaceVariant),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Text(
+                value,
+                style: theme.textTheme.bodyMedium?.copyWith(color: valueColor),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/data/model/transaction_type.dart';
+import 'package:rocket_pocket/screens/loan/loan_detail_header.dart';
+import 'package:rocket_pocket/screens/loan/loan_detail_info_card.dart';
+import 'package:rocket_pocket/screens/transaction/transaction_list_tile.dart';
+import 'package:rocket_pocket/viewmodels/pocket_view_model.dart';
+import 'package:rocket_pocket/viewmodels/transaction_view_model.dart';
+
+class LoanDetailScreen extends ConsumerStatefulWidget {
+  final Loan loan;
+
+  const LoanDetailScreen({super.key, required this.loan});
+
+  @override
+  ConsumerState<LoanDetailScreen> createState() => _LoanDetailScreenState();
+}
+
+class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
+  late final ScrollController _scrollController;
+  bool _isCollapsed = false;
+
+  static const double _expandedHeight = 280.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+    _scrollController.addListener(() {
+      final collapsed =
+          _scrollController.hasClients &&
+          _scrollController.offset > _expandedHeight - kToolbarHeight - 8;
+      if (collapsed != _isCollapsed) setState(() => _isCollapsed = collapsed);
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loan = widget.loan;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final remaining = loan.amount - loan.repaidAmount;
+    final progress =
+        loan.amount > 0
+            ? (loan.repaidAmount / loan.amount).clamp(0.0, 1.0)
+            : 0.0;
+    final isOverdue =
+        loan.status == LoanStatus.ongoing &&
+        loan.dueDate.isBefore(DateTime.now());
+
+    final transactionsAsync = ref.watch(transactionViewModelProvider);
+    final pockets = ref.watch(pocketViewModelProvider).valueOrNull ?? [];
+    final pocketCurrency = {
+      for (final p in pockets)
+        if (p.id != null) p.id!: p.currency,
+    };
+    final pocketName = {
+      for (final p in pockets)
+        if (p.id != null) p.id!: p.name,
+    };
+
+    final repaymentTransactions =
+        (transactionsAsync.valueOrNull ?? [])
+            .where(
+              (t) =>
+                  t.loanId == loan.id &&
+                  (t.type == TransactionType.loanRepayment ||
+                      t.type == TransactionType.loanCollection),
+            )
+            .toList()
+          ..sort((a, b) {
+            final aTime = a.date ?? a.createdAt ?? DateTime(0);
+            final bTime = b.date ?? b.createdAt ?? DateTime(0);
+            return bTime.compareTo(aTime);
+          });
+
+    final headerColor = switch (loan.status) {
+      LoanStatus.completed => colorScheme.primary,
+      LoanStatus.cancelled => colorScheme.outline,
+      LoanStatus.overdue || _ when isOverdue => colorScheme.error,
+      _ =>
+        loan.type == LoanType.given
+            ? colorScheme.tertiary
+            : colorScheme.secondary,
+    };
+
+    return Scaffold(
+      body: CustomScrollView(
+        controller: _scrollController,
+        slivers: [
+          // ── Expanded header ─────────────────────────────────────────
+          SliverAppBar(
+            pinned: true,
+            floating: false,
+            expandedHeight: _expandedHeight,
+            backgroundColor: headerColor,
+            foregroundColor: colorScheme.onPrimary,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.pop(),
+            ),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                onPressed: () {
+                  // TODO: navigate to edit loan screen
+                },
+              ),
+            ],
+            flexibleSpace: FlexibleSpaceBar(
+              collapseMode: CollapseMode.pin,
+              background: SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    20,
+                    kToolbarHeight,
+                    20,
+                    16,
+                  ),
+                  child: LoanDetailHeader(
+                    loan: loan,
+                    progress: progress,
+                    remaining: remaining,
+                    isOverdue: isOverdue,
+                    foregroundColor: colorScheme.onPrimary,
+                  ),
+                ),
+              ),
+              title:
+                  _isCollapsed
+                      ? Text(
+                        loan.counterpartyName,
+                        style: TextStyle(color: colorScheme.onPrimary),
+                      )
+                      : null,
+            ),
+          ),
+
+          // ── Details card ─────────────────────────────────────────────
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 20, bottom: 8),
+              child: LoanDetailInfoCard(loan: loan, isOverdue: isOverdue),
+            ),
+          ),
+
+          // ── Repayment transactions header ────────────────────────────
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Repayment Transactions',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    '${repaymentTransactions.length} records',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SliverToBoxAdapter(child: Divider(height: 1)),
+
+          // ── Transaction list ─────────────────────────────────────────
+          transactionsAsync.when(
+            loading:
+                () => const SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.all(32),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                ),
+            error:
+                (e, _) => SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(32),
+                    child: Center(child: Text('Error: $e')),
+                  ),
+                ),
+            data: (_) {
+              if (repaymentTransactions.isEmpty) {
+                return SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 48),
+                    child: Center(
+                      child: Text(
+                        'No repayment transactions yet',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }
+              return SliverList.builder(
+                itemCount: repaymentTransactions.length,
+                itemBuilder: (context, i) {
+                  final tx = repaymentTransactions[i];
+                  final currency =
+                      tx.senderPocketId != null
+                          ? (pocketCurrency[tx.senderPocketId] ?? 'IDR')
+                          : 'IDR';
+                  final pocket =
+                      tx.senderPocketId != null
+                          ? pocketName[tx.senderPocketId]
+                          : null;
+                  return TransactionListTile(
+                    transaction: tx,
+                    currency: currency,
+                    pocketName: pocket,
+                  );
+                },
+              );
+            },
+          ),
+
+          const SliverToBoxAdapter(child: SizedBox(height: 80)),
+        ],
+      ),
+      floatingActionButton:
+          loan.status == LoanStatus.ongoing || loan.status == LoanStatus.overdue
+              ? FloatingActionButton.extended(
+                onPressed: () {
+                  // TODO: navigate to add repayment transaction screen
+                },
+                icon: const Icon(Icons.add),
+                label: Text(
+                  loan.type == LoanType.given
+                      ? 'Record Collection'
+                      : 'Record Repayment',
+                ),
+              )
+              : null,
+    );
+  }
+}

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -24,6 +24,8 @@ class LoanDetailScreen extends ConsumerStatefulWidget {
 class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
   late final ScrollController _scrollController;
   bool _isCollapsed = false;
+  bool _fabVisible = true;
+  double _lastScrollOffset = 0;
 
   static const double _expandedHeight = 280.0;
 
@@ -32,10 +34,18 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
     super.initState();
     _scrollController = ScrollController();
     _scrollController.addListener(() {
-      final collapsed =
-          _scrollController.hasClients &&
-          _scrollController.offset > _expandedHeight - kToolbarHeight - 8;
+      if (!_scrollController.hasClients) return;
+      final offset = _scrollController.offset;
+
+      final collapsed = offset > _expandedHeight - kToolbarHeight - 8;
       if (collapsed != _isCollapsed) setState(() => _isCollapsed = collapsed);
+
+      final scrollingUp = offset < _lastScrollOffset;
+      final fabShouldBeVisible = scrollingUp || offset <= 0;
+      if (fabShouldBeVisible != _fabVisible) {
+        setState(() => _fabVisible = fabShouldBeVisible);
+      }
+      _lastScrollOffset = offset;
     });
   }
 
@@ -251,17 +261,23 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
       ),
       floatingActionButton:
           loan.status == LoanStatus.ongoing || loan.status == LoanStatus.overdue
-              ? FloatingActionButton.extended(
-                onPressed:
-                    () => context.push(
-                      Paths.addRepaymentRoute(loan.id!),
-                      extra: loan,
-                    ),
-                icon: const Icon(Icons.add),
-                label: Text(
-                  loan.type == LoanType.given
-                      ? 'Record Collection'
-                      : 'Record Repayment',
+              ? AnimatedScale(
+                scale: _fabVisible ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                alignment: Alignment.bottomRight,
+                child: FloatingActionButton.extended(
+                  onPressed:
+                      () => context.push(
+                        Paths.addRepaymentRoute(loan.id!),
+                        extra: loan,
+                      ),
+                  icon: const Icon(Icons.add),
+                  label: Text(
+                    loan.type == LoanType.given
+                        ? 'Record Collection'
+                        : 'Record Repayment',
+                  ),
                 ),
               )
               : null,

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -13,9 +13,15 @@ import 'package:rocket_pocket/viewmodels/pocket_view_model.dart';
 import 'package:rocket_pocket/viewmodels/transaction_view_model.dart';
 
 class LoanDetailScreen extends ConsumerStatefulWidget {
-  final Loan loan;
+  final Loan? loan;
+  final int? loanId;
 
-  const LoanDetailScreen({super.key, required this.loan});
+  const LoanDetailScreen({super.key, this.loan, this.loanId})
+    : assert(
+        loan != null || loanId != null,
+        'Either loan or loanId must be provided. '
+        'When both are given, loan.id takes precedence over loanId.',
+      );
 
   @override
   ConsumerState<LoanDetailScreen> createState() => _LoanDetailScreenState();
@@ -57,14 +63,32 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // Keep loan data fresh after edits or repayments.
-    final loans = ref.watch(loanViewModelProvider).valueOrNull;
-    final loan =
-        loans?.firstWhere(
-          (l) => l.id == widget.loan.id,
-          orElse: () => widget.loan,
-        ) ??
-        widget.loan;
+    final loansAsync = ref.watch(loanViewModelProvider);
+
+    // Resolve the effective id: prefer widget.loan.id, then widget.loanId.
+    final effectiveId = widget.loan?.id ?? widget.loanId;
+
+    // Resolve the loan from the provider list (keeps data fresh after edits/repayments).
+    final loans = loansAsync.valueOrNull;
+    final resolvedFromList =
+        effectiveId != null
+            ? loans?.where((l) => l.id == effectiveId).firstOrNull
+            : null;
+    final loan = resolvedFromList ?? widget.loan;
+
+    // When only a loanId was provided and the list is still loading (or the
+    // loan hasn't been found yet), show a spinner so the rest of the build
+    // can assume a non-null loan.
+    if (loan == null) {
+      if (loansAsync.isLoading) {
+        return const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        );
+      }
+      return Scaffold(
+        body: Center(child: Text('Loan #$effectiveId not found')),
+      );
+    }
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -113,9 +113,10 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
             actions: [
               IconButton(
                 icon: const Icon(Icons.edit_outlined),
-                onPressed: () {
-                  // TODO: navigate to edit loan screen
-                },
+                onPressed: () => context.push(
+                  Paths.editLoanRoute(loan.id!),
+                  extra: loan,
+                ),
               ),
             ],
             flexibleSpace: FlexibleSpaceBar(

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:rocket_pocket/data/model/transaction_type.dart';
 import 'package:rocket_pocket/screens/loan/loan_detail_header.dart';
 import 'package:rocket_pocket/screens/loan/loan_detail_info_card.dart';
 import 'package:rocket_pocket/screens/transaction/transaction_list_tile.dart';
+import 'package:rocket_pocket/router/paths.dart';
 import 'package:rocket_pocket/viewmodels/pocket_view_model.dart';
 import 'package:rocket_pocket/viewmodels/transaction_view_model.dart';
 
@@ -240,9 +241,11 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
       floatingActionButton:
           loan.status == LoanStatus.ongoing || loan.status == LoanStatus.overdue
               ? FloatingActionButton.extended(
-                onPressed: () {
-                  // TODO: navigate to add repayment transaction screen
-                },
+                onPressed:
+                    () => context.push(
+                      Paths.addRepaymentRoute(loan.id!),
+                      extra: loan,
+                    ),
                 icon: const Icon(Icons.add),
                 label: Text(
                   loan.type == LoanType.given

--- a/lib/screens/loan/loan_detail_screen.dart
+++ b/lib/screens/loan/loan_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:rocket_pocket/screens/loan/loan_detail_header.dart';
 import 'package:rocket_pocket/screens/loan/loan_detail_info_card.dart';
 import 'package:rocket_pocket/screens/transaction/transaction_list_tile.dart';
 import 'package:rocket_pocket/router/paths.dart';
+import 'package:rocket_pocket/viewmodels/loan_view_model.dart';
 import 'package:rocket_pocket/viewmodels/pocket_view_model.dart';
 import 'package:rocket_pocket/viewmodels/transaction_view_model.dart';
 
@@ -46,7 +47,14 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final loan = widget.loan;
+    // Keep loan data fresh after edits or repayments.
+    final loans = ref.watch(loanViewModelProvider).valueOrNull;
+    final loan =
+        loans?.firstWhere(
+          (l) => l.id == widget.loan.id,
+          orElse: () => widget.loan,
+        ) ??
+        widget.loan;
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -98,6 +106,7 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
     return Scaffold(
       body: CustomScrollView(
         controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
           // ── Expanded header ─────────────────────────────────────────
           SliverAppBar(
@@ -113,10 +122,11 @@ class _LoanDetailScreenState extends ConsumerState<LoanDetailScreen> {
             actions: [
               IconButton(
                 icon: const Icon(Icons.edit_outlined),
-                onPressed: () => context.push(
-                  Paths.editLoanRoute(loan.id!),
-                  extra: loan,
-                ),
+                onPressed:
+                    () => context.push(
+                      Paths.editLoanRoute(loan.id!),
+                      extra: loan,
+                    ),
               ),
             ],
             flexibleSpace: FlexibleSpaceBar(

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -1,10 +1,90 @@
 import 'package:flutter/material.dart';
 
-class LoanScreen extends StatelessWidget {
+class LoanScreen extends StatefulWidget {
   const LoanScreen({super.key});
 
   @override
+  State<LoanScreen> createState() => _LoanScreenState();
+}
+
+class _LoanScreenState extends State<LoanScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(child: Text('Loan Screen'));
+    return Scaffold(
+      body: NestedScrollView(
+        headerSliverBuilder:
+            (context, innerBoxIsScrolled) => [
+              SliverAppBar(
+                pinned: true,
+                floating: true,
+                forceElevated: innerBoxIsScrolled,
+                expandedHeight: 120.0,
+                flexibleSpace: const FlexibleSpaceBar(
+                  title: Text('Loans'),
+                  centerTitle: false,
+                  titlePadding: EdgeInsets.only(left: 16, bottom: 48),
+                ),
+                bottom: TabBar(
+                  controller: _tabController,
+                  tabs: const [
+                    Tab(text: 'Loans Given'),
+                    Tab(text: 'Loans Taken'),
+                  ],
+                ),
+              ),
+            ],
+        body: TabBarView(
+          controller: _tabController,
+          children: const [
+            _LoanListTab(type: _LoanTabType.given),
+            _LoanListTab(type: _LoanTabType.taken),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: navigate to add loan screen
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+enum _LoanTabType { given, taken }
+
+class _LoanListTab extends StatelessWidget {
+  final _LoanTabType type;
+
+  const _LoanListTab({required this.type});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: replace with real data from viewmodel
+    return Center(
+      child: Text(
+        type == _LoanTabType.given
+            ? 'No loans given yet'
+            : 'No loans taken yet',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class LoanScreen extends StatelessWidget {
+  const LoanScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('Loan Screen'));
+  }
+}

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:rocket_pocket/data/model/enums.dart';
 import 'package:rocket_pocket/data/model/loan.dart';
 import 'package:rocket_pocket/router/paths.dart';
 import 'package:rocket_pocket/screens/loan/loan_card.dart';
+import 'package:rocket_pocket/viewmodels/loan_view_model.dart';
 
-class LoanScreen extends StatefulWidget {
+class LoanScreen extends ConsumerStatefulWidget {
   const LoanScreen({super.key});
 
   @override
-  State<LoanScreen> createState() => _LoanScreenState();
+  ConsumerState<LoanScreen> createState() => _LoanScreenState();
 }
 
-class _LoanScreenState extends State<LoanScreen>
+class _LoanScreenState extends ConsumerState<LoanScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
 
@@ -30,6 +32,8 @@ class _LoanScreenState extends State<LoanScreen>
 
   @override
   Widget build(BuildContext context) {
+    final loansAsync = ref.watch(loanViewModelProvider);
+
     return Scaffold(
       body: NestedScrollView(
         headerSliverBuilder:
@@ -55,9 +59,17 @@ class _LoanScreenState extends State<LoanScreen>
             ],
         body: TabBarView(
           controller: _tabController,
-          children: const [
-            _LoanListTab(type: _LoanTabType.given),
-            _LoanListTab(type: _LoanTabType.taken),
+          children: [
+            _LoanListTab(
+              loansAsync: loansAsync,
+              type: LoanType.given,
+              emptyLabel: 'No loans given yet',
+            ),
+            _LoanListTab(
+              loansAsync: loansAsync,
+              type: LoanType.taken,
+              emptyLabel: 'No loans taken yet',
+            ),
           ],
         ),
       ),
@@ -69,90 +81,50 @@ class _LoanScreenState extends State<LoanScreen>
   }
 }
 
-enum _LoanTabType { given, taken }
-
 class _LoanListTab extends StatelessWidget {
-  final _LoanTabType type;
+  final AsyncValue<List<Loan>> loansAsync;
+  final LoanType type;
+  final String emptyLabel;
 
-  const _LoanListTab({required this.type});
-
-  // TODO: replace with real data from viewmodel
-  static final _stubLoans = [
-    Loan(
-      id: 1,
-      type: LoanType.given,
-      counterpartyName: 'Alice',
-      amount: 500000,
-      description: 'Emergency fund',
-      startDate: DateTime(2026, 1, 10),
-      dueDate: DateTime(2026, 4, 10),
-      status: LoanStatus.ongoing,
-      repaidAmount: 200000,
-      createdAt: DateTime(2026, 1, 10),
-    ),
-    Loan(
-      id: 2,
-      type: LoanType.given,
-      counterpartyName: 'Bob',
-      amount: 200000,
-      description: 'Laptop purchase',
-      startDate: DateTime(2025, 11, 1),
-      dueDate: DateTime(2026, 2, 1),
-      status: LoanStatus.ongoing,
-      repaidAmount: 0,
-      createdAt: DateTime(2025, 11, 1),
-    ),
-    Loan(
-      id: 3,
-      type: LoanType.taken,
-      counterpartyName: 'Jane',
-      amount: 1000000,
-      description: 'Rent advance',
-      startDate: DateTime(2026, 2, 1),
-      dueDate: DateTime(2026, 8, 1),
-      status: LoanStatus.ongoing,
-      repaidAmount: 300000,
-      createdAt: DateTime(2026, 2, 1),
-    ),
-  ];
+  const _LoanListTab({
+    required this.loansAsync,
+    required this.type,
+    required this.emptyLabel,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final loans =
-        _stubLoans
-            .where(
-              (l) =>
-                  type == _LoanTabType.given
-                      ? l.type == LoanType.given
-                      : l.type == LoanType.taken,
-            )
-            .toList();
+    return loansAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (loans) {
+        final filtered = loans.where((l) => l.type == type).toList();
 
-    if (loans.isEmpty) {
-      return Center(
-        child: Text(
-          type == _LoanTabType.given
-              ? 'No loans given yet'
-              : 'No loans taken yet',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
-        ),
-      );
-    }
+        if (filtered.isEmpty) {
+          return Center(
+            child: Text(
+              emptyLabel,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          );
+        }
 
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: loans.length,
-      itemBuilder:
-          (context, index) => LoanCard(
-            loan: loans[index],
-            onTap:
-                () => context.push(
-                  Paths.loanDetailsRoute(loans[index].id!),
-                  extra: loans[index],
-                ),
-          ),
+        return ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          itemCount: filtered.length,
+          itemBuilder:
+              (context, index) => LoanCard(
+                loan: filtered[index],
+                onTap:
+                    () => context.push(
+                      Paths.loanDetailsRoute(filtered[index].id!),
+                      extra: filtered[index],
+                    ),
+              ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -38,7 +38,7 @@ class _LoanScreenState extends State<LoanScreen>
                 pinned: true,
                 floating: true,
                 forceElevated: innerBoxIsScrolled,
-                expandedHeight: 120.0,
+                expandedHeight: 182.0,
                 flexibleSpace: const FlexibleSpaceBar(
                   title: Text('Loans'),
                   centerTitle: false,
@@ -62,9 +62,7 @@ class _LoanScreenState extends State<LoanScreen>
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          // TODO: navigate to add loan screen
-        },
+        onPressed: () => context.push(Paths.addLoan),
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:rocket_pocket/data/model/enums.dart';
 import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/router/paths.dart';
 import 'package:rocket_pocket/screens/loan/loan_card.dart';
 
 class LoanScreen extends StatefulWidget {
@@ -147,9 +149,11 @@ class _LoanListTab extends StatelessWidget {
       itemBuilder:
           (context, index) => LoanCard(
             loan: loans[index],
-            onTap: () {
-              // TODO: navigate to loan detail screen
-            },
+            onTap:
+                () => context.push(
+                  Paths.loanDetailsRoute(loans[index].id!),
+                  extra: loans[index],
+                ),
           ),
     );
   }

--- a/lib/screens/loan/loan_screen.dart
+++ b/lib/screens/loan/loan_screen.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/screens/loan/loan_card.dart';
 
 class LoanScreen extends StatefulWidget {
   const LoanScreen({super.key});
@@ -73,18 +76,81 @@ class _LoanListTab extends StatelessWidget {
 
   const _LoanListTab({required this.type});
 
+  // TODO: replace with real data from viewmodel
+  static final _stubLoans = [
+    Loan(
+      id: 1,
+      type: LoanType.given,
+      counterpartyName: 'Alice',
+      amount: 500000,
+      description: 'Emergency fund',
+      startDate: DateTime(2026, 1, 10),
+      dueDate: DateTime(2026, 4, 10),
+      status: LoanStatus.ongoing,
+      repaidAmount: 200000,
+      createdAt: DateTime(2026, 1, 10),
+    ),
+    Loan(
+      id: 2,
+      type: LoanType.given,
+      counterpartyName: 'Bob',
+      amount: 200000,
+      description: 'Laptop purchase',
+      startDate: DateTime(2025, 11, 1),
+      dueDate: DateTime(2026, 2, 1),
+      status: LoanStatus.ongoing,
+      repaidAmount: 0,
+      createdAt: DateTime(2025, 11, 1),
+    ),
+    Loan(
+      id: 3,
+      type: LoanType.taken,
+      counterpartyName: 'Jane',
+      amount: 1000000,
+      description: 'Rent advance',
+      startDate: DateTime(2026, 2, 1),
+      dueDate: DateTime(2026, 8, 1),
+      status: LoanStatus.ongoing,
+      repaidAmount: 300000,
+      createdAt: DateTime(2026, 2, 1),
+    ),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    // TODO: replace with real data from viewmodel
-    return Center(
-      child: Text(
-        type == _LoanTabType.given
-            ? 'No loans given yet'
-            : 'No loans taken yet',
-        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
+    final loans =
+        _stubLoans
+            .where(
+              (l) =>
+                  type == _LoanTabType.given
+                      ? l.type == LoanType.given
+                      : l.type == LoanType.taken,
+            )
+            .toList();
+
+    if (loans.isEmpty) {
+      return Center(
+        child: Text(
+          type == _LoanTabType.given
+              ? 'No loans given yet'
+              : 'No loans taken yet',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
-      ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: loans.length,
+      itemBuilder:
+          (context, index) => LoanCard(
+            loan: loans[index],
+            onTap: () {
+              // TODO: navigate to loan detail screen
+            },
+          ),
     );
   }
 }

--- a/lib/screens/root/root_screen.dart
+++ b/lib/screens/root/root_screen.dart
@@ -17,8 +17,8 @@ class _RootScreenState extends State<RootScreen> {
     NavigationDestination(icon: Icon(Icons.dashboard), label: 'Dashboard'),
     NavigationDestination(icon: Icon(Icons.swap_horiz), label: 'Transaction'),
     NavigationDestination(icon: Icon(Icons.wallet), label: 'Budget'),
-    NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
     NavigationDestination(icon: Icon(Icons.handshake), label: 'Loan'),
+    NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
   ];
 
   @override

--- a/lib/screens/root/root_screen.dart
+++ b/lib/screens/root/root_screen.dart
@@ -18,6 +18,7 @@ class _RootScreenState extends State<RootScreen> {
     NavigationDestination(icon: Icon(Icons.swap_horiz), label: 'Transaction'),
     NavigationDestination(icon: Icon(Icons.wallet), label: 'Budget'),
     NavigationDestination(icon: Icon(Icons.settings), label: 'Settings'),
+    NavigationDestination(icon: Icon(Icons.handshake), label: 'Loan'),
   ];
 
   @override

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -11,4 +11,5 @@ export 'settings/settings_screen.dart';
 export 'transaction/add_transaction_screen.dart';
 export 'transaction/transaction_screen.dart';
 export 'loan/loan_screen.dart';
+export 'loan/add_loan_screen.dart';
 export 'loan/loan_detail_screen.dart';

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -10,3 +10,4 @@ export 'root/root_screen.dart';
 export 'settings/settings_screen.dart';
 export 'transaction/add_transaction_screen.dart';
 export 'transaction/transaction_screen.dart';
+export 'loan/loan_screen.dart';

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -12,4 +12,5 @@ export 'transaction/add_transaction_screen.dart';
 export 'transaction/transaction_screen.dart';
 export 'loan/loan_screen.dart';
 export 'loan/add_loan_screen.dart';
+export 'loan/add_repayment_screen.dart';
 export 'loan/loan_detail_screen.dart';

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -11,3 +11,4 @@ export 'settings/settings_screen.dart';
 export 'transaction/add_transaction_screen.dart';
 export 'transaction/transaction_screen.dart';
 export 'loan/loan_screen.dart';
+export 'loan/loan_detail_screen.dart';

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -13,4 +13,5 @@ export 'transaction/transaction_screen.dart';
 export 'loan/loan_screen.dart';
 export 'loan/add_loan_screen.dart';
 export 'loan/add_repayment_screen.dart';
+export 'loan/edit_loan_screen.dart';
 export 'loan/loan_detail_screen.dart';

--- a/lib/screens/transaction/add_transaction_screen.dart
+++ b/lib/screens/transaction/add_transaction_screen.dart
@@ -44,22 +44,32 @@ class AddTransactionScreen extends ConsumerWidget {
                         style: Theme.of(context).textTheme.labelLarge,
                       ),
                       const SizedBox(height: 8),
-                      SegmentedButton<TransactionType>(
-                        showSelectedIcon: false,
-                        segments:
-                            TransactionType.values
-                                .map(
-                                  (t) => ButtonSegment(
-                                    value: t,
-                                    label: Text(t.toReadableString()),
-                                  ),
-                                )
-                                .toList(),
-                        selected: {state.selectedType},
-                        onSelectionChanged:
-                            (value) => ref
-                                .read(addTransactionViewModelProvider.notifier)
-                                .setType(value.first),
+                      SizedBox(
+                        width: double.infinity,
+                        child: SegmentedButton<TransactionType>(
+                          showSelectedIcon: false,
+                          segments: const [
+                            ButtonSegment(
+                              value: TransactionType.income,
+                              label: Text('Income'),
+                            ),
+                            ButtonSegment(
+                              value: TransactionType.expense,
+                              label: Text('Expense'),
+                            ),
+                            ButtonSegment(
+                              value: TransactionType.transfer,
+                              label: Text('Transfer'),
+                            ),
+                          ],
+                          selected: {state.selectedType},
+                          onSelectionChanged:
+                              (value) => ref
+                                  .read(
+                                    addTransactionViewModelProvider.notifier,
+                                  )
+                                  .setType(value.first),
+                        ),
                       ),
                       const SizedBox(height: 24),
 
@@ -252,37 +262,6 @@ class AddTransactionScreen extends ConsumerWidget {
                                   .setCategory(c);
                             }
                           },
-                        ),
-                        const SizedBox(height: 16),
-                      ],
-
-                      // ── Original Transaction (Refund only) ────────────
-                      if (state.selectedType == TransactionType.refund) ...[
-                        DropdownButtonFormField<int>(
-                          value: state.originalTransactionId,
-                          decoration: const InputDecoration(
-                            labelText: 'Original Transaction',
-                            border: OutlineInputBorder(),
-                            icon: Icon(Icons.receipt_long),
-                          ),
-                          items:
-                              state.refundableTransactions
-                                  .map(
-                                    (t) => DropdownMenuItem(
-                                      value: t.id,
-                                      child: Text(
-                                        '${t.description} — ${t.formattedAmount}',
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ),
-                                  )
-                                  .toList(),
-                          onChanged:
-                              (id) => ref
-                                  .read(
-                                    addTransactionViewModelProvider.notifier,
-                                  )
-                                  .setOriginalTransactionId(id),
                         ),
                         const SizedBox(height: 16),
                       ],

--- a/lib/viewmodels/add_loan_view_model.dart
+++ b/lib/viewmodels/add_loan_view_model.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rocket_pocket/data/model/enums.dart';
 import 'package:rocket_pocket/data/model/loan.dart';
 import 'package:rocket_pocket/repositories/loan_repository.dart';
+import 'package:rocket_pocket/viewmodels/loan_view_model.dart';
 
 class AddLoanState {
   final LoanType selectedType;
@@ -110,7 +111,9 @@ class AddLoanViewModel extends AsyncNotifier<AddLoanState> {
       );
 
       await _loanRepository.insertLoan(loan.toInsertCompanion());
-      ref.invalidate(addLoanViewModelProvider);
+      ref.invalidate(loanViewModelProvider);
+      // Reset form state directly instead of self-invalidating
+      state = AsyncData(AddLoanState());
     } catch (e, stack) {
       state = AsyncError(e, stack);
       rethrow;

--- a/lib/viewmodels/add_loan_view_model.dart
+++ b/lib/viewmodels/add_loan_view_model.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/repositories/loan_repository.dart';
+
+class AddLoanState {
+  final LoanType selectedType;
+  final String counterpartyName;
+  final double amount;
+  final String description;
+  final DateTime startDate;
+  final DateTime dueDate;
+
+  AddLoanState({
+    this.selectedType = LoanType.given,
+    this.counterpartyName = '',
+    this.amount = 0,
+    this.description = '',
+    DateTime? startDate,
+    DateTime? dueDate,
+  }) : startDate = startDate ?? DateTime.now(),
+       dueDate = dueDate ?? DateTime.now().add(const Duration(days: 30));
+
+  bool get isValid => counterpartyName.trim().isNotEmpty && amount > 0;
+
+  AddLoanState copyWith({
+    LoanType? selectedType,
+    String? counterpartyName,
+    double? amount,
+    String? description,
+    DateTime? startDate,
+    DateTime? dueDate,
+  }) {
+    return AddLoanState(
+      selectedType: selectedType ?? this.selectedType,
+      counterpartyName: counterpartyName ?? this.counterpartyName,
+      amount: amount ?? this.amount,
+      description: description ?? this.description,
+      startDate: startDate ?? this.startDate,
+      dueDate: dueDate ?? this.dueDate,
+    );
+  }
+}
+
+final addLoanViewModelProvider =
+    AsyncNotifierProvider<AddLoanViewModel, AddLoanState>(AddLoanViewModel.new);
+
+class AddLoanViewModel extends AsyncNotifier<AddLoanState> {
+  late LoanRepository _loanRepository;
+
+  @override
+  FutureOr<AddLoanState> build() {
+    _loanRepository = ref.watch(loanRepositoryProvider);
+    return AddLoanState();
+  }
+
+  void setType(LoanType type) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(selectedType: type));
+  }
+
+  void setCounterpartyName(String name) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(counterpartyName: name));
+  }
+
+  void setAmount(double amount) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(amount: amount));
+  }
+
+  void setDescription(String description) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(description: description));
+  }
+
+  void setStartDate(DateTime date) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(startDate: date));
+  }
+
+  void setDueDate(DateTime date) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(dueDate: date));
+  }
+
+  Future<void> submit() async {
+    final current = state.valueOrNull;
+    if (current == null || !current.isValid) return;
+
+    state = const AsyncLoading();
+    try {
+      final loan = Loan(
+        type: current.selectedType,
+        counterpartyName: current.counterpartyName.trim(),
+        amount: current.amount,
+        description: current.description.trim(),
+        startDate: current.startDate,
+        dueDate: current.dueDate,
+        status: LoanStatus.ongoing,
+        repaidAmount: 0,
+        createdAt: DateTime.now(),
+      );
+
+      await _loanRepository.insertLoan(loan.toInsertCompanion());
+      ref.invalidate(addLoanViewModelProvider);
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+      rethrow;
+    }
+  }
+}

--- a/lib/viewmodels/add_loan_view_model.dart
+++ b/lib/viewmodels/add_loan_view_model.dart
@@ -83,7 +83,14 @@ class AddLoanViewModel extends AsyncNotifier<AddLoanState> {
   void setStartDate(DateTime date) {
     final current = state.valueOrNull;
     if (current == null) return;
-    state = AsyncData(current.copyWith(startDate: date));
+    final adjustedDueDate =
+        current.dueDate.isBefore(date) ? date : current.dueDate;
+    state = AsyncData(
+      current.copyWith(
+        startDate: date,
+        dueDate: adjustedDueDate,
+      ),
+    );
   }
 
   void setDueDate(DateTime date) {

--- a/lib/viewmodels/add_repayment_view_model.dart
+++ b/lib/viewmodels/add_repayment_view_model.dart
@@ -110,12 +110,16 @@ class AddRepaymentViewModel extends AsyncNotifier<AddRepaymentState> {
               ? TransactionType.loanCollection
               : TransactionType.loanRepayment;
 
+      // Guard against overpayment: clamp to the remaining balance.
+      final remaining = loan.amount - loan.repaidAmount;
+      final amount = current.amount.clamp(0.0, remaining);
+
       final transaction = Transaction(
         type: transactionType,
         senderPocketId: current.selectedPocket!.id,
         loanId: loan.id,
         description: current.description.trim(),
-        amount: current.amount,
+        amount: amount,
         date: current.date,
       );
 
@@ -127,7 +131,6 @@ class AddRepaymentViewModel extends AsyncNotifier<AddRepaymentState> {
 
         // Update pocket balance
         final pocket = current.selectedPocket!;
-        final amount = current.amount;
         if (transactionType.isPositive) {
           // loanCollection — money coming in, credit pocket
           await _pocketRepository.updatePocket(
@@ -140,9 +143,18 @@ class AddRepaymentViewModel extends AsyncNotifier<AddRepaymentState> {
           );
         }
 
-        // Update loan's repaid amount
+        // Update loan's repaid amount.
         final newRepaidAmount = loan.repaidAmount + amount;
         await _loanRepository.updateRepaidAmount(loan.id!, newRepaidAmount);
+
+        // Auto-complete the loan when fully repaid.
+        if (newRepaidAmount >= loan.amount &&
+            loan.status != LoanStatus.completed) {
+          await _loanRepository.updateLoanStatus(
+            loan.id!,
+            LoanStatus.completed,
+          );
+        }
       });
 
       ref.invalidate(pocketViewModelProvider);

--- a/lib/viewmodels/add_repayment_view_model.dart
+++ b/lib/viewmodels/add_repayment_view_model.dart
@@ -148,7 +148,14 @@ class AddRepaymentViewModel extends AsyncNotifier<AddRepaymentState> {
       ref.invalidate(pocketViewModelProvider);
       ref.invalidate(transactionViewModelProvider);
       ref.invalidate(loanViewModelProvider);
-      ref.invalidate(addRepaymentViewModelProvider);
+      // Reset form state directly instead of self-invalidating
+      final pockets = await _pocketRepository.getAllPockets();
+      state = AsyncData(
+        AddRepaymentState(
+          pockets: pockets,
+          selectedPocket: pockets.isNotEmpty ? pockets.first : null,
+        ),
+      );
     } catch (e, stack) {
       state = AsyncError(e, stack);
       rethrow;

--- a/lib/viewmodels/add_repayment_view_model.dart
+++ b/lib/viewmodels/add_repayment_view_model.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rocket_pocket/data/local/database.dart' as db;
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
+import 'package:rocket_pocket/data/model/pocket.dart';
+import 'package:rocket_pocket/data/model/transaction.dart';
+import 'package:rocket_pocket/data/model/transaction_type.dart';
+import 'package:rocket_pocket/repositories/loan_repository.dart';
+import 'package:rocket_pocket/repositories/pocket_repository.dart';
+import 'package:rocket_pocket/repositories/transaction_repository.dart';
+import 'package:rocket_pocket/viewmodels/loan_view_model.dart';
+import 'package:rocket_pocket/viewmodels/pocket_view_model.dart';
+import 'package:rocket_pocket/viewmodels/transaction_view_model.dart';
+
+class AddRepaymentState {
+  final List<Pocket> pockets;
+  final Pocket? selectedPocket;
+  final double amount;
+  final String description;
+  final DateTime date;
+
+  AddRepaymentState({
+    required this.pockets,
+    this.selectedPocket,
+    this.amount = 0,
+    this.description = '',
+    DateTime? date,
+  }) : date = date ?? DateTime.now();
+
+  bool get isValid => selectedPocket != null && amount > 0;
+
+  AddRepaymentState copyWith({
+    List<Pocket>? pockets,
+    Object? selectedPocket = _absent,
+    double? amount,
+    String? description,
+    DateTime? date,
+  }) {
+    return AddRepaymentState(
+      pockets: pockets ?? this.pockets,
+      selectedPocket:
+          selectedPocket == _absent
+              ? this.selectedPocket
+              : selectedPocket as Pocket?,
+      amount: amount ?? this.amount,
+      description: description ?? this.description,
+      date: date ?? this.date,
+    );
+  }
+}
+
+const Object _absent = Object();
+
+final addRepaymentViewModelProvider =
+    AsyncNotifierProvider<AddRepaymentViewModel, AddRepaymentState>(
+      AddRepaymentViewModel.new,
+    );
+
+class AddRepaymentViewModel extends AsyncNotifier<AddRepaymentState> {
+  late PocketRepository _pocketRepository;
+  late TransactionRepository _transactionRepository;
+  late LoanRepository _loanRepository;
+
+  @override
+  FutureOr<AddRepaymentState> build() async {
+    _pocketRepository = ref.watch(pocketRepositoryProvider);
+    _transactionRepository = ref.watch(transactionRepositoryProvider);
+    _loanRepository = ref.watch(loanRepositoryProvider);
+
+    final pockets = await _pocketRepository.getAllPockets();
+    return AddRepaymentState(
+      pockets: pockets,
+      selectedPocket: pockets.isNotEmpty ? pockets.first : null,
+    );
+  }
+
+  void setSelectedPocket(Pocket pocket) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(selectedPocket: pocket));
+  }
+
+  void setAmount(double amount) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(amount: amount));
+  }
+
+  void setDescription(String description) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(description: description));
+  }
+
+  void setDate(DateTime date) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(date: date));
+  }
+
+  Future<void> submit(Loan loan) async {
+    final current = state.valueOrNull;
+    if (current == null || !current.isValid) return;
+
+    state = const AsyncLoading();
+    try {
+      final transactionType =
+          loan.type == LoanType.given
+              ? TransactionType.loanCollection
+              : TransactionType.loanRepayment;
+
+      final transaction = Transaction(
+        type: transactionType,
+        senderPocketId: current.selectedPocket!.id,
+        loanId: loan.id,
+        description: current.description.trim(),
+        amount: current.amount,
+        date: current.date,
+      );
+
+      final database = ref.read(db.appDatabaseProvider);
+      await database.transaction(() async {
+        await _transactionRepository.insertTransaction(
+          transaction.toInsertCompanion(),
+        );
+
+        // Update pocket balance
+        final pocket = current.selectedPocket!;
+        final amount = current.amount;
+        if (transactionType.isPositive) {
+          // loanCollection — money coming in, credit pocket
+          await _pocketRepository.updatePocket(
+            pocket.copyWith(balance: pocket.balance + amount),
+          );
+        } else {
+          // loanRepayment — money going out, debit pocket
+          await _pocketRepository.updatePocket(
+            pocket.copyWith(balance: pocket.balance - amount),
+          );
+        }
+
+        // Update loan's repaid amount
+        final newRepaidAmount = loan.repaidAmount + amount;
+        await _loanRepository.updateRepaidAmount(loan.id!, newRepaidAmount);
+      });
+
+      ref.invalidate(pocketViewModelProvider);
+      ref.invalidate(transactionViewModelProvider);
+      ref.invalidate(loanViewModelProvider);
+      ref.invalidate(addRepaymentViewModelProvider);
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+      rethrow;
+    }
+  }
+}

--- a/lib/viewmodels/loan_view_model.dart
+++ b/lib/viewmodels/loan_view_model.dart
@@ -1,47 +1,38 @@
-import 'package:rocket_pocket/data/local/database.dart';
-import 'package:rocket_pocket/data/model/enums.dart';
-import 'package:rocket_pocket/utils/error_handler/app_error.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rocket_pocket/data/local/database.dart' show LoansCompanion;
+import 'package:rocket_pocket/data/model/enums.dart';
+import 'package:rocket_pocket/data/model/loan.dart';
 import 'package:rocket_pocket/repositories/loan_repository.dart';
+import 'package:rocket_pocket/utils/error_handler/app_error.dart';
 
-/// This is the view model for managing loans in the application.
-/// It uses the [LoanRepository] to perform CRUD operations on loans.
 final loanViewModelProvider = AsyncNotifierProvider<LoanViewModel, List<Loan>>(
-  (ref) {
-        final loanRepository = ref.read(loanRepositoryProvider);
-        return LoanViewModel(loanRepository);
-      }
-      as LoanViewModel Function(),
+  LoanViewModel.new,
 );
 
-/// The [LoanViewModel] class extends [AsyncNotifier] to manage the state of loans.
 class LoanViewModel extends AsyncNotifier<List<Loan>> {
-  late final LoanRepository _loanRepository;
-
-  LoanViewModel(this._loanRepository);
+  late LoanRepository _loanRepository;
 
   @override
   Future<List<Loan>> build() async {
+    _loanRepository = ref.watch(loanRepositoryProvider);
     return await _fetchLoans();
   }
 
-  /// Fetches all loans from the repository and updates the state.
   Future<List<Loan>> _fetchLoans() async {
     try {
-      return await _loanRepository.getAllLoans();
+      final rows = await _loanRepository.getAllLoans();
+      return rows.map(Loan.fromDb).toList();
     } on AppError catch (e) {
       state = AsyncError(e, e.stackTrace);
       e.throwError();
     }
   }
 
-  /// Refreshes the list of loans by calling [_fetchLoans] and updating the state.
   Future<void> refreshLoans() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() => _fetchLoans());
   }
 
-  /// Adds a new loan to the repository and refreshes the list of loans.
   Future<void> addLoan(LoansCompanion loan) async {
     try {
       await _loanRepository.insertLoan(loan);
@@ -52,47 +43,48 @@ class LoanViewModel extends AsyncNotifier<List<Loan>> {
     }
   }
 
-  /// Fetches a loan by its ID.
   Future<Loan?> getLoanById(int id) async {
     try {
-      return await _loanRepository.getLoanById(id);
+      final row = await _loanRepository.getLoanById(id);
+      return row != null ? Loan.fromDb(row) : null;
     } on AppError catch (e) {
       state = AsyncError(e, e.stackTrace);
       e.throwError();
     }
   }
 
-  /// Fetches loans by their status.
   Future<List<Loan>> getLoansByStatus(LoanStatus status) async {
     try {
-      return await _loanRepository.getLoansByStatus(status);
+      final rows = await _loanRepository.getLoansByStatus(status);
+      return rows.map(Loan.fromDb).toList();
     } on AppError catch (e) {
       state = AsyncError(e, e.stackTrace);
       e.throwError();
     }
   }
 
-  /// Fetches loans by their type.
   Future<List<Loan>> getLoansByType(LoanType type) async {
     try {
-      return await _loanRepository.getLoansByType(type);
+      final rows = await _loanRepository.getLoansByType(type);
+      return rows.map(Loan.fromDb).toList();
     } on AppError catch (e) {
       state = AsyncError(e, e.stackTrace);
       e.throwError();
     }
   }
 
-  /// Fetches loans by the counterparty name.'
   Future<List<Loan>> getLoansByCounterpartyName(String counterpartyName) async {
     try {
-      return await _loanRepository.getLoansByCounterpartyName(counterpartyName);
+      final rows = await _loanRepository.getLoansByCounterpartyName(
+        counterpartyName,
+      );
+      return rows.map(Loan.fromDb).toList();
     } on AppError catch (e) {
       state = AsyncError(e, e.stackTrace);
       e.throwError();
     }
   }
 
-  /// Updates an existing loan in the repository and refreshes the list of loans.
   Future<void> updateLoan(LoansCompanion loan) async {
     try {
       await _loanRepository.updateLoan(loan);
@@ -103,7 +95,6 @@ class LoanViewModel extends AsyncNotifier<List<Loan>> {
     }
   }
 
-  /// Updates the status of a loan in the repository and refreshes the list of loans.
   Future<void> updateStatus(int id, LoanStatus status) async {
     try {
       await _loanRepository.updateLoanStatus(id, status);


### PR DESCRIPTION
- [x] Previous PR work (routing fallback, LoanDetailScreen loanId support)
- [x] Fix `updateLoanStatus` bug in `loan_repository.dart` (`Value(status.name as LoanStatus)` → `Value(status)`)
- [x] In `add_repayment_view_model.dart` `submit`: clamp amount to remaining to prevent overpayment
- [x] Auto-set loan status to `LoanStatus.completed` when `newRepaidAmount >= loan.amount`

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.